### PR TITLE
Add guideline for how to create a kite plugin in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to Kite plugins
+## Contribute to Kite plugins
 
 First of all, thank you for contributing to Kite plugins! We're glad that you're joining us to bring Kite live to more editors and help more programmers code better and faster! 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To support sending events to Kite:
  - The cursor position is represented as a selection with `start == end` (see below).
  - These events should only be sent for the currently active buffer. Changes made to a non-active file (e.g. through multi-file find/replace) should not be sent.
 
-3. The ability to write json blobs to a unix domain socket:
+3. The ability to write json blobs to a unix domain socket (or UDP, more details to come):
  - `libkited` listens to json objects sent to `$HOME/.kite/kite.sock`
  - A typical example of json structure being sent by vim is:
 ```javascript


### PR DESCRIPTION
@alexflint @tarakju cc: @adamsmith 

This PR adds the guideline for creating a Kite plugin. I copied the content from `https://github.com/kiteco/projects/issues/15`, but removed some of them that need not be exposed to out siders. You can check https://github.com/kiteco/plugins/commit/6e705d7acd2c89b085411bc2e659541d779a0cfd to see the exact changes.

Also let me know if you'd like me to remove/edit the contents.

I also moved the known issues section and created issues in this repo.
